### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apk add --no-cache \
     && apk add --no-cache --virtual .build-deps \
         py-pip \
     && pip install -r requirements.txt \
-    && apk del .build-deps \
+    && apk del --no-cache .build-deps \
     && addgroup -g 1000 aaisp \
     && adduser -u 1000 -G aaisp -s /bin/sh -D aaisp \
-    && chown aaisp:aaisp -R /app
+    && chown aaisp:aaisp -R /app \
+    && echo "0 * * * * /usr/bin/python /app/aaisp-to-mqtt.py /app/config.cfg" | crontab -u aaisp -
 
 EXPOSE 8080/tcp
-USER aaisp
-CMD ["python", "aaisp-to-mqtt.py", "config.cfg"]
+CMD ["/usr/sbin/crond", "-f", "-d", "8"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,4 @@ RUN apk add --no-cache \
     && chown aaisp:aaisp -R /app \
     && echo "0 * * * * /usr/bin/python /app/aaisp-to-mqtt.py /app/config.cfg" | crontab -u aaisp -
 
-EXPOSE 8080/tcp
 CMD ["/usr/sbin/crond", "-f", "-d", "8"]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ aaisp/login/gb12@a.1/syncrate/up                1205000
 aaisp/login/gb12@a.1/syncrate/up/human          1.21 MB
 ```
 
+## Docker ##
+
+Build the Docker image with:
+
+```
+docker build -t aaisp-mqtt .
+```
+
+Run the container with a volume mounted config file:
+
+```
+docker run -d -v <path_to_config>:/app/config.cfg --name AAISPmqtt aaisp-mqtt
+```
+
 ## Setup ##
 
 TODO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-paho-mqtt>=1.2,<1.3
+paho-mqtt>=1.2
 configparser>=3.5.0
 humanfriendly>=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-paho-mqtt>=1.2
+paho-mqtt>=1.2,<1.3
 configparser>=3.5.0
 humanfriendly>=2.1


### PR DESCRIPTION
Hope you do not mind I have fixed up the Docker build and improved it a bit.

I stumbled across your repo today and attempted to build the Docker image to find that pytest-runner (a dependency of paho-mqtt) was failing to install within the virtualenv due to ca-certificates not being available. fcf76aa fixes this issue directly if you wish to cherry-pick that by specifying the max paho-mqtt version rather than merge the whole PR.

This PR also includes my tweaks to the Docker image with a few changes, namely:

- Smaller overall image size (44.2MB instead of the original 227MB)
- Added cron support to trigger the python script every hour without externally triggering the Docker container
- Python script now run as unprivileged "aaisp" user rather than root (crond is run as root though)
- Removal of Python virtualenv (personally not a fan of these as Docker serves as the container, especially running unprivileged - happy to discuss though 😄 )
